### PR TITLE
RHMAP 7944 Add UPS user and database generation

### DIFF
--- a/5.5/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/common.sh
@@ -125,6 +125,14 @@ mysql $mysql_flags <<EOSQL
 EOSQL
   fi
 
+  if [ -v UPS_USER ]; then
+    log_info "Creating user specified by MYSQL_USER (${UPS_USER}) ..."
+mysql $mysql_flags <<EOSQL
+    CREATE USER '${UPS_USER}'@'%' IDENTIFIED BY '${UPS_PASSWORD}';
+EOSQL
+  fi
+
+
   if [ -v MYSQL_DATABASE ]; then
     log_info "Creating database ${MYSQL_DATABASE} ..."
     mysqladmin $admin_flags create "${MYSQL_DATABASE}"
@@ -132,6 +140,18 @@ EOSQL
       log_info "Granting privileges to user ${MYSQL_USER} for ${MYSQL_DATABASE} ..."
 mysql $mysql_flags <<EOSQL
       GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
+      FLUSH PRIVILEGES ;
+EOSQL
+    fi
+  fi
+
+  if [ -v UPS_DATABASE ]; then
+    log_info "Creating database ${UPS_DATABASE} ..."
+    mysqladmin $admin_flags create "${UPS_DATABASE}"
+    if [ -v UPS_USER ]; then
+      log_info "Granting privileges to user ${UPS_USER} for ${UPS_DATABASE} ..."
+mysql $mysql_flags <<EOSQL
+      GRANT ALL ON \`${UPS_DATABASE}\`.* TO '${UPS_USER}'@'%' ;
       FLUSH PRIVILEGES ;
 EOSQL
     fi


### PR DESCRIPTION
Part of Jira: https://issues.jboss.org/browse/RHMAP-7792

@wtrocki can you take a look

Verified by running `make build VERSION=5.5`, running the container with following env vars (you could just use a modified template too):

* `MYSQL_USER`
* `MYSQL_PASSWORD`
* `MYSQL_DATABASE`
* `MYSQL_ROOT_PASSWORD`
* `UPS_USER`
* `UPS_PASSWORD`
* `UPS_DATABASE`

Then just run the following to get into the container and list some info.
`docker exec -it containerID bash`

`mysql -u root`

`show databases;`

`select User from mysql.user;`
